### PR TITLE
fix: add try/catch when parsing JSON

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -29,8 +29,12 @@ class Client {
               reject(err);
             } else {
               if (options && options.json && res.body && res.response.headers["content-type"] && res.response.headers["content-type"].startsWith(CONTENT_TYPE.ApplicationJson)) {
-                res.json = JSON.parse(res.body);
-                resolve(res);
+                try {
+                  res.json = JSON.parse(res.body);
+                  resolve(res);
+                } catch (error) {
+                  reject(error);
+                }
               } else {
                 resolve(res);
               }


### PR DESCRIPTION
> ## What?
> Added `try/catch` block when using `JSON.parse`.
> 
> ## Why?
> On some edge cases when the response brings back some malformed JSON it throws an Unhandled error, difficulting to properly handle the error.
> 
